### PR TITLE
fix: make ToString() extensionsamplingfrequence index map lookup more resilient.

### DIFF
--- a/src/SharpMp4Parser/IsoParser/Boxes/ISO14496/Part1/ObjectDescriptors/AudioSpecificConfig.cs
+++ b/src/SharpMp4Parser/IsoParser/Boxes/ISO14496/Part1/ObjectDescriptors/AudioSpecificConfig.cs
@@ -1097,7 +1097,11 @@ namespace SharpMp4Parser.IsoParser.Boxes.ISO14496.Part1.ObjectDescriptors
                 sb.Append(", extensionAudioObjectType=").Append(extensionAudioObjectType).Append(" (").Append(audioObjectTypeMap[extensionAudioObjectType]).Append(")");
                 sb.Append(", sbrPresentFlag=").Append(sbrPresentFlag);
                 sb.Append(", psPresentFlag=").Append(psPresentFlag);
-                sb.Append(", extensionSamplingFrequencyIndex=").Append(extensionSamplingFrequencyIndex).Append(" (").Append(samplingFrequencyIndexMap[extensionSamplingFrequencyIndex]).Append(")");
+                sb.Append($", extensionSamplingFrequencyIndex={extensionSamplingFrequencyIndex}");
+                if (samplingFrequencyIndexMap.TryGetValue(extensionSamplingFrequencyIndex, out var samplingFrequencyDescription))
+                {
+                    sb.Append($" ({samplingFrequencyDescription})");
+                }
                 sb.Append(", extensionSamplingFrequency=").Append(extensionSamplingFrequency);
                 sb.Append(", extensionChannelConfiguration=").Append(extensionChannelConfiguration);
             }


### PR DESCRIPTION
This is a problem for ESDS with an extension object, but no sbr present. This appears to be common in ffmpeg's default packaged aac encoder.

The fix will do a `TryGetValue` on the sampling frequency map, and only include the value if it was found. 